### PR TITLE
Modify access token retrieval instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,37 +82,7 @@ Before proceeding with the Quickstart, ensure you have obtained the Access Token
    Received code: na1-129d-860c-xxxx-xxxx-xxxxxxxxxxxx
    ```
 
-4. Run the following ballerina program or curl command. Replace the `<YOUR_CLIENT_ID>`, `<YOUR_REDIRECT_URI`> and `<YOUR_CLIENT_SECRET>` with your specific value. Use the code you received in the above step 3 as the `<CODE>`.
-
-- Ballerina Program
-
-```ballerina
-      import ballerina/http;
-      import ballerina/io;
-
-      configurable string clientId = ?;
-      configurable string clientSecret = ?;
-      configurable string redirectUri = ?;
-      configurable string code = ?;
-
-      public function main() returns error? {
-         http:Client hubspotClient = check new ("https://api.hubapi.com");
-
-         // Construct the form-urlencoded payload
-         string payload = string `grant_type=authorization_code&code=${code}&redirect_uri=${redirectUri}&client_id=${clientId}&client_secret=${clientSecret}`;
-
-         http:Request tokenRequest = new;
-         tokenRequest.setPayload(payload);
-         tokenRequest.setHeader("Content-Type", "application/x-www-form-urlencoded");
-
-         // Send POST request to fetch the access token
-         http:Response tokenResponse = check hubspotClient->post("/oauth/v1/token", tokenRequest);
-
-         // Parse and print the response
-         json responseJson = check tokenResponse.getJsonPayload();
-         io:println("Access and Refresh Token Response: ", responseJson);
-      }
-   ```
+4. Run the following curl command. Replace the `<YOUR_CLIENT_ID>`, `<YOUR_REDIRECT_URI`> and `<YOUR_CLIENT_SECRET>` with your specific value. Use the code you received in the above step 3 as the `<CODE>`.
 
    - Linux/macOS
 

--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -75,37 +75,7 @@ Before proceeding with the Quickstart, ensure you have obtained the Access Token
    Received code: na1-129d-860c-xxxx-xxxx-xxxxxxxxxxxx
    ```
 
-4. Run the following ballerina program or curl command. Replace the `<YOUR_CLIENT_ID>`, `<YOUR_REDIRECT_URI`> and `<YOUR_CLIENT_SECRET>` with your specific value. Use the code you received in the above step 3 as the `<CODE>`.
-
-- Ballerina Program
-
-```ballerina
-      import ballerina/http;
-      import ballerina/io;
-
-      configurable string clientId = ?;
-      configurable string clientSecret = ?;
-      configurable string redirectUri = ?;
-      configurable string code = ?;
-
-      public function main() returns error? {
-         http:Client hubspotClient = check new ("https://api.hubapi.com");
-
-         // Construct the form-urlencoded payload
-         string payload = string `grant_type=authorization_code&code=${code}&redirect_uri=${redirectUri}&client_id=${clientId}&client_secret=${clientSecret}`;
-
-         http:Request tokenRequest = new;
-         tokenRequest.setPayload(payload);
-         tokenRequest.setHeader("Content-Type", "application/x-www-form-urlencoded");
-
-         // Send POST request to fetch the access token
-         http:Response tokenResponse = check hubspotClient->post("/oauth/v1/token", tokenRequest);
-
-         // Parse and print the response
-         json responseJson = check tokenResponse.getJsonPayload();
-         io:println("Access and Refresh Token Response: ", responseJson);
-      }
-   ```
+4. Run the following curl command. Replace the `<YOUR_CLIENT_ID>`, `<YOUR_REDIRECT_URI`> and `<YOUR_CLIENT_SECRET>` with your specific value. Use the code you received in the above step 3 as the `<CODE>`.
 
    - Linux/macOS
 

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -74,37 +74,9 @@ Before proceeding with the Quickstart, ensure you have obtained the Access Token
    Received code: na1-129d-860c-xxxx-xxxx-xxxxxxxxxxxx
    ```
 
-4. Run the following ballerina program or curl command. Replace the `<YOUR_CLIENT_ID>`, `<YOUR_REDIRECT_URI`> and `<YOUR_CLIENT_SECRET>` with your specific value. Use the code you received in the above step 3 as the `<CODE>`.
+4. Run the following curl command. Replace the `<YOUR_CLIENT_ID>`, `<YOUR_REDIRECT_URI`> and `<YOUR_CLIENT_SECRET>` with your specific value. Use the code you received in the above step 3 as the `<CODE>`.
 
 - Ballerina Program
-
-```ballerina
-      import ballerina/http;
-      import ballerina/io;
-
-      configurable string clientId = ?;
-      configurable string clientSecret = ?;
-      configurable string redirectUri = ?;
-      configurable string code = ?;
-
-      public function main() returns error? {
-         http:Client hubspotClient = check new ("https://api.hubapi.com");
-
-         // Construct the form-urlencoded payload
-         string payload = string `grant_type=authorization_code&code=${code}&redirect_uri=${redirectUri}&client_id=${clientId}&client_secret=${clientSecret}`;
-
-         http:Request tokenRequest = new;
-         tokenRequest.setPayload(payload);
-         tokenRequest.setHeader("Content-Type", "application/x-www-form-urlencoded");
-
-         // Send POST request to fetch the access token
-         http:Response tokenResponse = check hubspotClient->post("/oauth/v1/token", tokenRequest);
-
-         // Parse and print the response
-         json responseJson = check tokenResponse.getJsonPayload();
-         io:println("Access and Refresh Token Response: ", responseJson);
-      }
-   ```
 
    - Linux/macOS
 


### PR DESCRIPTION
Update the documentation to remove the Ballerina program example for obtaining access and refresh tokens, simplifying the instructions to only include a curl command.