### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Ballerina Ballerina HubSpot CRM Lineitems Connector connector
+# Ballerina HubSpot CRM Lineitems connector
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.object.lineitems.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.object.lineitems)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.object.lineitems.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.object.lineitems)
 
 ## Overview
 
@@ -16,7 +16,7 @@ To use the HubSpot Line items connector, you must have access to the HubSpot API
 
 ### Step 01 : Create/ Login to a HubSpot Developer Account
 
- If you have an account already go to the [Hubspot account portal](https://app.hubspot.com/myaccounts-beta)
+ If you have an account already go to the [HubSpot account portal](https://app.hubspot.com/myaccounts-beta)
 
  If you don't have a developer account, register for a free HubSpot developer account.[(click here)](https://app.hubspot.com/signup-hubspot/developers?_ga=2.207749649.2047916093.1734412948-232493525.1734412948&step=landing_page)
 
@@ -28,11 +28,11 @@ Note: These accounts are only for development and testing purposes. In productio
 
 1. Go to Test Account section from the left sidebar.
 
-   ![Hubspot Developer Portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/test_acc_1.png)
+   ![HubSpot Developer Portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/test_acc_1.png)
 
 2. Click Create developer test account.
 
-   ![Hubspot Developer Test Account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/test_acc_2.png)
+   ![HubSpot Developer Test Account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/test_acc_2.png)
 
 3. Create developer test account by providing a name
 
@@ -56,15 +56,15 @@ Click on `Create App`
    * `crm.objects.line_items.read`
    * `crm.objects.line_items.write`
 
-   ![Hubspot set scope](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/image-2.png)
+   ![HubSpot set scope](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/image-2.png)
 
 3. Add your Redirect URI in the relevant section. You can also use localhost addresses for local development purposes. Click Create App.
-   ![Hubspot create app final](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/create_app_final.png)
+   ![HubSpot create app final](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/create_app_final.png)
 
 ### Step 5: Get your Client ID and Client Secret
 
 - Navigate to the Auth section of your app. Make sure to save the provided Client ID and Client Secret.
-  ![Hubspot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/get_credentials.png)
+  ![HubSpot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/get_credentials.png)
 
 ### Step 6: Setup Authentication Flow
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Ballerina HubSpot CRM Lineitems connector
 
-[![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/actions/workflows/ci.yml)
-[![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.object.lineitems.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.object.lineitems)
+[![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/actions/workflows/ci.yml)
+[![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/commits/master)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.obj.lineitems.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.obj.lineitems)
 
 ## Overview
 
@@ -28,11 +28,11 @@ Note: These accounts are only for development and testing purposes. In productio
 
 1. Go to Test Account section from the left sidebar.
 
-   ![HubSpot Developer Portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/test_acc_1.png)
+   ![HubSpot Developer Portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/test_acc_1.png)
 
 2. Click Create developer test account.
 
-   ![HubSpot Developer Test Account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/test_acc_2.png)
+   ![HubSpot Developer Test Account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/test_acc_2.png)
 
 3. Create developer test account by providing a name
 
@@ -40,7 +40,7 @@ Note: These accounts are only for development and testing purposes. In productio
 
 1. In your developer account, navigate to the [Apps](https://app.hubspot.com/developer/48567544/applications) section.
 Click on `Create App`
-   ![create app](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/create_app_1.png)
+   ![create app](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/create_app_1.png)
 
 2. Provide the necessary details, including the app name and description.
 
@@ -48,7 +48,7 @@ Click on `Create App`
 
 1. Move to the Auth tab.
 
-   ![alt text](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/image.png)
+   ![alt text](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/image.png)
 
 2. In the Scopes section, add necessary scopes for your app using the "Add new scope" button. For line items API connector we will have to add the following 3 scopes in addition to the existing `oauth` scope.
 
@@ -56,15 +56,15 @@ Click on `Create App`
    * `crm.objects.line_items.read`
    * `crm.objects.line_items.write`
 
-   ![HubSpot set scope](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/image-2.png)
+   ![HubSpot set scope](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/image-2.png)
 
 3. Add your Redirect URI in the relevant section. You can also use localhost addresses for local development purposes. Click Create App.
-   ![HubSpot create app final](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/create_app_final.png)
+   ![HubSpot create app final](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/create_app_final.png)
 
 ### Step 5: Get your Client ID and Client Secret
 
 - Navigate to the Auth section of your app. Make sure to save the provided Client ID and Client Secret.
-  ![HubSpot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/get_credentials.png)
+  ![HubSpot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/get_credentials.png)
 
 ### Step 6: Setup Authentication Flow
 
@@ -196,10 +196,10 @@ bal run
 
 ## Examples
 
-The `Ballerina HubSpot CRM Lineitems Connector` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/module-ballerinax-hubspot.crm.object.lineitems/tree/main/examples/), covering the following use cases:
+The `Ballerina HubSpot CRM Lineitems Connector` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/tree/main/examples/), covering the following use cases:
 
-1. [Customer Order fulfillment](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/tree/main/examples/customer-order-fulfillment) - Manage customer orders in a warehouse system
-2. [Inventory management](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/tree/main/examples/inventory-management) - Manage inventory for an operational deal in an E-commerce platform
+1. [Customer Order fulfillment](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/tree/main/examples/customer-order-fulfillment) - Manage customer orders in a warehouse system
+2. [Inventory management](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/tree/main/examples/inventory-management) - Manage inventory for an operational deal in an E-commerce platform
 
 ## Build from the source
 
@@ -289,7 +289,7 @@ All the contributors are encouraged to read the [Ballerina Code of Conduct](http
 
 ## Useful links
 
-* For more information go to the [`hubspot.crm.object.lineitems` package](https://central.ballerina.io/ballerinax/hubspot.crm.obj.lineitems/latest).
+* For more information go to the [`hubspot.crm.obj.lineitems` package](https://central.ballerina.io/ballerinax/hubspot.crm.obj.lineitems/latest).
 * For example demonstrations of the usage, go to [Ballerina By Examples](https://ballerina.io/learn/by-example/).
 * Chat live with us via our [Discord server](https://discord.gg/ballerinalang).
 * Post all technical questions on Stack Overflow with the [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag.

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -6,7 +6,7 @@ version = "2.0.1"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Type/Connector", "Area/CRM & Sales", "Vendor/HubSpot"]
-repository = "https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems"
+repository = "https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems"
 icon = "icon.png"
 
 [build-options]

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -17,7 +17,7 @@ To use the HubSpot Line items connector, you must have access to the HubSpot API
 
 ### Step 01 : Create/Login to a HubSpot Developer Account
 
- If you have an account already go to the [Hubspot account portal](https://app.hubspot.com/myaccounts-beta)
+ If you have an account already go to the [HubSpot account portal](https://app.hubspot.com/myaccounts-beta)
 
  If you don't have a developer account, register for a free HubSpot developer account.[(click here)](https://app.hubspot.com/signup-hubspot/developers?_ga=2.207749649.2047916093.1734412948-232493525.1734412948&step=landing_page)
 
@@ -29,11 +29,11 @@ Note: These accounts are only for development and testing purposes. In productio
 
 1. Go to Test Account section from the left sidebar.
 
-   ![Hubspot Developer Portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/test_acc_1.png)
+   ![HubSpot Developer Portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/test_acc_1.png)
 
 2. Click Create developer test account.
 
-   ![Hubspot Developer Test Account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/test_acc_2.png)
+   ![HubSpot Developer Test Account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/test_acc_2.png)
 
 3. Create developer test account by providing a name
 
@@ -57,15 +57,15 @@ Click on `Create App`
    * `crm.objects.line_items.read`
    * `crm.objects.line_items.write`
 
-   ![Hubspot set scope](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/image-2.png)
+   ![HubSpot set scope](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/image-2.png)
 
 3. Add your Redirect URI in the relevant section. You can also use localhost addresses for local development purposes. Click Create App.
-   ![Hubspot create app final](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/create_app_final.png)
+   ![HubSpot create app final](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/create_app_final.png)
 
 ### Step 5: Get your Client ID and Client Secret
 
 - Navigate to the Auth section of your app. Make sure to save the provided Client ID and Client Secret.
-  ![Hubspot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/get_credentials.png)
+  ![HubSpot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/get_credentials.png)
 
 ### Step 6: Setup Authentication Flow
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -29,11 +29,11 @@ Note: These accounts are only for development and testing purposes. In productio
 
 1. Go to Test Account section from the left sidebar.
 
-   ![HubSpot Developer Portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/test_acc_1.png)
+   ![HubSpot Developer Portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/test_acc_1.png)
 
 2. Click Create developer test account.
 
-   ![HubSpot Developer Test Account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/test_acc_2.png)
+   ![HubSpot Developer Test Account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/test_acc_2.png)
 
 3. Create developer test account by providing a name
 
@@ -41,7 +41,7 @@ Note: These accounts are only for development and testing purposes. In productio
 
 1. In your developer account, navigate to the [Apps](https://app.hubspot.com/developer/48567544/applications) section.
 Click on `Create App`
-   ![create app](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/create_app_1.png)
+   ![create app](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/create_app_1.png)
 
 2. Provide the necessary details, including the app name and description.
 
@@ -49,7 +49,7 @@ Click on `Create App`
 
 1. Move to the Auth tab.
 
-   ![alt text](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/image.png)
+   ![alt text](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/image.png)
 
 2. In the Scopes section, add necessary scopes for your app using the "Add new scope" button. For line items API connector we will have to add the following 3 scopes in addition to the existing `oauth` scope.
 
@@ -57,15 +57,15 @@ Click on `Create App`
    * `crm.objects.line_items.read`
    * `crm.objects.line_items.write`
 
-   ![HubSpot set scope](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/image-2.png)
+   ![HubSpot set scope](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/image-2.png)
 
 3. Add your Redirect URI in the relevant section. You can also use localhost addresses for local development purposes. Click Create App.
-   ![HubSpot create app final](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/create_app_final.png)
+   ![HubSpot create app final](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/create_app_final.png)
 
 ### Step 5: Get your Client ID and Client Secret
 
 - Navigate to the Auth section of your app. Make sure to save the provided Client ID and Client Secret.
-  ![HubSpot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/main/docs/setup/resources/get_credentials.png)
+  ![HubSpot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/main/docs/setup/resources/get_credentials.png)
 
 ### Step 6: Setup Authentication Flow
 
@@ -197,7 +197,7 @@ bal run
 
 ## Examples
 
-The `Ballerina HubSpot CRM Lineitems Connector` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/module-ballerinax-hubspot.crm.object.lineitems/tree/main/examples/), covering the following use cases:
+The `Ballerina HubSpot CRM Lineitems Connector` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/tree/main/examples/), covering the following use cases:
 
-1. [Customer Order fulfillment](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/tree/main/examples/customer-order-fulfillment) - Manage customer orders in a warehouse system
-2. [Inventory management](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems/tree/main/examples/inventory-management) - Manage inventory for an operational deal in an E-commerce platform
+1. [Customer Order fulfillment](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/tree/main/examples/customer-order-fulfillment) - Manage customer orders in a warehouse system
+2. [Inventory management](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems/tree/main/examples/inventory-management) - Manage inventory for an operational deal in an E-commerce platform

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -82,7 +82,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/ballerina-platform/module-${packageOrg}-hubspot.crm.object.lineitems")
+            url = uri("https://maven.pkg.github.com/ballerina-platform/module-${packageOrg}-${packageName}")
             credentials {
                 username = System.getenv("publishUser")
                 password = System.getenv("publishPAT")

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -6,7 +6,7 @@ version = "@toml.version@"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Type/Connector", "Area/CRM & Sales", "Vendor/HubSpot"]
-repository = "https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.lineitems"
+repository = "https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.lineitems"
 icon = "icon.png"
 
 [build-options]


### PR DESCRIPTION
## Purpose

Fix README content issues identified in the HubSpot connector audit for the `ballerinax/hubspot.crm.obj.lineitems` connector.

## Changes

- Add ballerina-platform/ prefix to the bare github.com/module-ballerinax-... URLs in the Examples section
- Update references to module-ballerinax-hubspot.crm.object.lineitems to the canonical post-rename .obj.lineitems (badges, image URLs, issue-label encoding, examples links)

## Checklist
- [x] Linked to an issue (Refs `ballerina-platform/ballerina-library#8823`)
- [ ] Updated the changelog — N/A (docs-only)
- [ ] Added tests — N/A (docs-only)
- [ ] Updated the spec — N/A (docs-only)
- [x] Checked native-image compatibility — N/A (no code change)

Refs ballerina-platform/ballerina-library#8823